### PR TITLE
Include: Fake dongle mode

### DIFF
--- a/config_rtl.py
+++ b/config_rtl.py
@@ -30,17 +30,17 @@ dongle_id=""
 rtl_tcp_host = 'localhost'
 rtl_tcp_port = 1234
 
-setuid_on_start = 0						# we normally start with root privileges and setuid() to another user
-uid = 999 									# determine by issuing: $ id -u username
-ignore_clients_without_commands = 1 # we won't serve data to telnet sessions and things like that
-												# we'll start to serve data after getting the first valid command 
+setuid_on_start = 0	# we normally start with root privileges and setuid() to another user
+uid = 999		# determine by issuing: $ id -u username
+ignore_clients_without_commands = 1	# we won't serve data to telnet sessions and things like that
+					# we'll start to serve data after getting the first valid command 
 freq_allowed_ranges = [[0000000,2200000000]]
 # Allow from all: freq_allowed_ranges = [[24000000,2200000000]]
 
 client_cant_set_until=0		
 first_client_can_set=True	#openwebrx - spectrum thread will set things on start # no good, clients set parameters and things
-buffer_size=25000000	# per client
-log_file_path = "/dev/null" # Might be set to /dev/null to turn off logging
+buffer_size=25000000		# per client
+log_file_path = "/dev/null"	# Might be set to /dev/null to turn off logging
 '''
 Allow any host to connect:
 	use_ip_access_control=0
@@ -63,8 +63,8 @@ denied_ip_ranges=()
 allowed_ip_ranges=()
 allow_gain_set=1
 
-use_dsp_command=False # you can process raw I/Q data with a custom command that starts a process that we can pipe the data into, and also pipe out of.
-debug_dsp_command=False # show sample rate before and after the dsp command
+use_dsp_command=False	# you can process raw I/Q data with a custom command that starts a process that we can pipe the data into, and also pipe out of.
+debug_dsp_command=False	# show sample rate before and after the dsp command
 dsp_command=""
 
 '''

--- a/config_rtl.py
+++ b/config_rtl.py
@@ -27,8 +27,8 @@ send_first=""
 #            + chr(0x00) + chr(0x00) + chr(0x00) + chr(0x05)
 #            ) # if you like to rewrite the DONGLE-ID. Required when using fake dongle.
 dongle_id=""
-rtl_tcp_host = 'localhost'
-rtl_tcp_port = 1234
+rtl_tcp_host = 'localhost'	# set to "" (NULL) when you use the fake dongle.
+rtl_tcp_port = 1234		# when you set to 0 you're enabling the fake dongle!
 
 setuid_on_start = 0	# we normally start with root privileges and setuid() to another user
 uid = 999		# determine by issuing: $ id -u username
@@ -64,8 +64,37 @@ allowed_ip_ranges=()
 allow_gain_set=1
 
 use_dsp_command=False	# you can process raw I/Q data with a custom command that starts a process that we can pipe the data into, and also pipe out of.
+			# when using the fake dongle mode it's mandatory to enable the DSP
 debug_dsp_command=False	# show sample rate before and after the dsp command
-dsp_command=""
+dsp_command=""			# when using the fake dongle mode this it's required
+dsp_chunk_size=1024		# use values like '16348','1024','16384'. It's the size of READ chunks from the DSP process. Recomendation: use the same value as the command in the DSP process  
+dsp_sampling_rate=250000	# when using the fake dongle it's required to resynch
+dsp_resynch_loop=1		# number of reads when resynching using the fake dongle
+'''
+Example of fake dongle mode: reading samples from a FIFO file
+
+# Read from fifo "/raw-fifo" in chunks of 16384 bytes
+dsp_command="dd if=/raw-fifo bs=16384 status=noxfer"
+
+# Set the sampling rate for regular 2048000 Msps
+dsp_sampling_rate=2048000
+
+# Do a resynch every 8 loops (try with 8,16,32 values) 
+dsp_resynch_loop=8
+
+Reset client values
+rtl_tcp_host=""
+rtl_tcp_port=0 # mandatory for fake dongle
+use_dsp_command=True # mandatory for fake dongle
+debug_dsp_command=True # recomended
+watchdog_interval=0 # disable it
+
+Set the Dongle-ID
+dongle_id = ( chr(0x52) + chr(0x54) + chr(0x4c) + chr(0x30)
+            + chr(0x00) + chr(0x00) + chr(0x00) + chr(0x02)
+            + chr(0x00) + chr(0x00) + chr(0x00) + chr(0x05)
+            ) # example for simulating a generic RTL2832U
+'''
 
 '''
 Example DSP commands:

--- a/config_rtl.py
+++ b/config_rtl.py
@@ -22,6 +22,11 @@ my_listening_port = 7373
 
 #send_first=chr(9)+chr(0)+chr(0)+chr(0)+chr(1) # set direct sampling
 send_first=""
+#dongle_id = ( chr(0x52) + chr(0x54) + chr(0x4c) + chr(0x30)
+#            + chr(0x00) + chr(0x00) + chr(0x00) + chr(0x02)
+#            + chr(0x00) + chr(0x00) + chr(0x00) + chr(0x05)
+#            ) # if you like to rewrite the DONGLE-ID. Required when using fake dongle.
+dongle_id=""
 rtl_tcp_host = 'localhost'
 rtl_tcp_port = 1234
 

--- a/config_rtl.py
+++ b/config_rtl.py
@@ -71,10 +71,13 @@ dsp_chunk_size=1024		# use values like '16348','1024','16384'. It's the size of 
 dsp_sampling_rate=250000	# when using the fake dongle it's required to resynch
 dsp_resynch_loop=1		# number of reads when resynching using the fake dongle
 '''
-Example of fake dongle mode: reading samples from a FIFO file
+Example of fake dongle mode: reading samples from a FIFO file for IQ samples
 
 # Read from fifo "/raw-fifo" in chunks of 16384 bytes
 dsp_command="dd if=/raw-fifo bs=16384 status=noxfer"
+
+# This is the correct value for IQ samples at 2048000 sample rate
+dsp_chunk_size=16384
 
 # Set the sampling rate for regular 2048000 Msps
 dsp_sampling_rate=2048000

--- a/rtl_mus.py
+++ b/rtl_mus.py
@@ -464,7 +464,7 @@ def main():
 	log.info("Server is UP")
 	
 	server_missing_logged=0	# Not to flood the screen with messages related to rtl_tcp disconnect
-	rtl_dongle_identifier='' # rtl_tcp sends some identifier on dongle type and gain values in the first few bytes right after connection
+	rtl_dongle_identifier=cfg.dongle_id # rtl_tcp sends some identifier on dongle type and gain values in the first few bytes right after connection. When !='' then use a fake value
 	clients=[]
 	dsp_data_count=original_data_count=0
 	commands=multiprocessing.Queue()


### PR DESCRIPTION
Hi,

This patch enables the "fake dongle mode". In this mode the client is disabled, so no real RTL_TCP server is required. Instead of reading samples from this server, the samples are come from the DSP process.

You can use this mode for reading the samples from a RAW file and then inject them to any RTL-SDR program. The output it's generated based on the sample rate configured, so the RTL-SDR program can get the clock from the samples.

As future work, the watchdog would need to be able to restart the DSP process if it receives an EOF.

Regards.